### PR TITLE
Update sql.py

### DIFF
--- a/ringmaster/sql.py
+++ b/ringmaster/sql.py
@@ -85,9 +85,7 @@ class DatabaseFunction(object):
     def __call__(self, *args):
         """Run a function in the database with positional arguments."""
         res = self.conn.execute(
-            select([
-                getattr(func, self.name)(*args)
-            ])
+            select(getattr(func, self.name)(*args))
         )
         return res
     


### PR DESCRIPTION
Update select call so `sqlalchemy>=2` works (as its latest API is installed by default as a requirement to ringmaster).